### PR TITLE
Load libraries for using them functions

### DIFF
--- a/lisp/magithub.el
+++ b/lisp/magithub.el
@@ -29,7 +29,9 @@
 
 ;;; Code:
 
+(require 'magit)
 (require 'magit-process)
+(require 'magit-popup)
 
 (defcustom magithub-hub-executable "hub"
   "The hub executable used by Magithub."


### PR DESCRIPTION
This fixes loading error.

```
(void-function magit-define-popup)
(void-variable magit-status-mode-map)
```