### PR TITLE
Fix error when remote "origin" is absent

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -29,8 +29,9 @@
 (defun magithub-github-repository-p ()
   "Non-nil if \"origin\" points to GitHub or a whitelisted domain."
   (let ((url (magit-get "remote" "origin" "url")))
-    (cl-some (lambda (domain) (s-contains? domain url))
-             (cons "github.com" (magit-get-all "hub" "host")))))
+    (when url
+      (cl-some (lambda (domain) (s-contains? domain url))
+               (cons "github.com" (magit-get-all "hub" "host"))))))
 
 (defun magithub-repo-id ()
   "Returns an identifying value for this repository."


### PR DESCRIPTION
If there is no remote named "origin", then `url` will be nil, and a wrong-type-argument error will be triggered by the call to `s-contains?`. This change removes the error (instead returning `nil`).