### PR TITLE
Merge PRs locally

### DIFF
--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -184,6 +184,13 @@ If `issue' is nil, open the repository's issues page."
        (plist-get issue :url)
      (car (magithub--command-output "browse" '("--url-only" "--" "issues"))))))
 
+(defun magithub-pr-merge-locally (issue)
+  "Merges `issue' locally using `hub am -3'."
+  (interactive (list (magit-section-value
+                      (magit-current-section))))
+  (magithub--command-output "am" `("-3" ,(plist-get issue :url)))
+  (magithub-issue-refresh))
+
 (defun magithub-issue-refresh ()
   (interactive)
   (magithub-cache-clear (magithub-repo-id) :issues)

--- a/magithub.el
+++ b/magithub.el
@@ -64,6 +64,7 @@
              (?f "Fork" magithub-fork-popup)
              (?i "Issues" magithub-issues-popup)
              (?p "Submit a pull request" magithub-pull-request-popup)
+             (?m "Merge a pull request locally" magithub-pr-merge-locally)
              "Meta"
              (?` "Toggle Magithub-Status integration" magithub-enabled-toggle)
              (?g "Refresh all GitHub data" magithub-refresh)


### PR DESCRIPTION
It can be useful to merge existing PRs locally to test them, etc.  Add a
function and a pop-up binding to do this.

Fixes #14
