### PR TITLE
Clean up dependencies

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,9 +7,4 @@
 
 (development
  (depends-on "ert")
- (depends-on "ert-runner")
- (depends-on "magit")
- (depends-on "git-commit")
- (depends-on "with-editor")
- (depends-on "cl-lib")
- (depends-on "s"))
+ (depends-on "ert-runner"))

--- a/magithub.el
+++ b/magithub.el
@@ -5,7 +5,7 @@
 ;; Author: Sean Allred <code@seanallred.com>
 ;; Keywords: git, tools, vc
 ;; Homepage: https://github.com/vermiculus/magithub
-;; Package-Requires: ((emacs "24.4") (magit "2.8.0") (git-commit "20160821.1338") (with-editor "20160828.1025") (cl-lib "1.0") (s "20160711.525"))
+;; Package-Requires: ((emacs "24.4") (magit "2.8.0") (git-commit "20160821.1338") (with-editor "20160828.1025") (s "20160711.525"))
 ;; Package-Version: 0.1
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- cl-lib was bundled since Emacs 24.3
- Package dependencies are read by package-file cask command