### PR TITLE
Ping with -n to avoid slow DNS lookups

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -42,7 +42,7 @@
   (let ((magit-git-executable "ping")
         (magit-pre-call-git-hook nil)
         (magit-git-global-arguments nil))
-    (= 0 (magit-git-exit-code "-c 1" "api.github.com"))))
+    (= 0 (magit-git-exit-code "-c 1" "-n" "api.github.com"))))
 
 (defun magithub--completing-read-multiple (prompt collection)
   "Using PROMPT, get a list of elements in COLLECTION.


### PR DESCRIPTION
I noticed magithub being very slow, causing Emacs to freeze.  Looking at the process tree I saw a ping command to api.github.com running.  When I ran "ping -c1 api.github.com" manually, it was also very slow.  I found that adding the "-n" option to disable DNS lookups fixed the problem.  I don't know why it was taking so long, but it's unnecessary to do an rDNS lookup anyway.  This fixes the problem.  :)

By the way, I think that it shouldn't ping the API server every time anyway.  If it does it at all, it should probably do it, like, once per Emacs session.  What do you think?

Thanks for working on this project.