### PR TITLE
Require s in libraries that use it

### DIFF
--- a/magithub-ci.el
+++ b/magithub-ci.el
@@ -28,6 +28,7 @@
 (require 'magit-section)
 (require 'magit-popup)
 (require 'dash)
+(require 's)
 
 (require 'magithub-core)
 (require 'magithub-cache)

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -26,6 +26,7 @@
 
 (require 'magit)
 (require 'dash)
+(require 's)
 
 (defun magithub-github-repository-p ()
   "Non-nil if \"origin\" points to GitHub or a whitelisted domain."

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -27,6 +27,7 @@
 (require 'magit)
 (require 'magit-section)
 (require 'dash)
+(require 's)
 
 (require 'magithub-core)
 (require 'magithub-cache)


### PR DESCRIPTION
By the way, I would prefer if you did not use `s` at all. I am all in on `dash` but don't feel the same way about `s`. It seems unnecessary and would prefer if people didn't use its function at least in cases where an equivalent built-in function exists. Just saying.
