### PR TITLE
Verify repo hosted by github before checking API availability

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -299,9 +299,9 @@ See /.github/ISSUE_TEMPLATE.md in this repository."
 (defun magithub-usable-p ()
   "Non-nil if Magithub should do its thing."
   (and (magithub-enabled-p)
+       (magithub-github-repository-p)
        (or (magithub-offline-p)
-           (magithub--api-available-p))
-       (magithub-github-repository-p)))
+           (magithub--api-available-p))))
 
 (defun magithub-error (err-message tag &optional trace)
   "Report a Magithub error."


### PR DESCRIPTION
The current implementation of magit-usable-p checks the API is
available before it checks whether the repo is hosted by github or a
whitelisted hub instance. Since the API availability check utilizes a
cache that is not repo host specific, this defeats the github hosted
check in the case where a mix of github and non-github hosted
repositories are used, resulting in magithub frequently concluding
that magithub is usable on non-github hosted repositories.

This commit fixes the problem for non-github hosted repositories by
moving the check for github or a whitelisted hub instance before the
API availability check. This eliminates the most annoying problem I've
encountered, being prompted for authentication and on repositories
where it will never succeed, having to cancel it, and then tell
magithub to go offline.

However, it does not address a problem when multiple different github
hosts are in use (e.g. github.com and an enterprise github instance)
and the API works on one of them but not the other. For that, the
cache implementation will have to be enhanced to understand multiple
hosts.

Partially fixes issue #110