### PR TITLE
When getting CI status, try both upstream and push remote

### DIFF
--- a/magithub-ci.el
+++ b/magithub-ci.el
@@ -50,8 +50,8 @@ If magithub.ci.enabled is not set, CI is considered to be enabled."
   "If this is a GitHub repository, insert the CI status header."
   (when (and (magithub-ci-enabled-p)
              (magithub-usable-p)
-             (magit-get-upstream-remote
-              (magit-get-current-branch)))
+             (or (magit-get-upstream-remote (magit-get-current-branch))
+                 (magit-get-push-remote (magit-get-current-branch))))
     (magithub-insert-ci-status-header)))
 
 (defun magithub-ci-toggle ()


### PR DESCRIPTION
This fixes the issue where some people may only have one remote set up (but valid) and got no CI status.

I ran into this issue and it took me a while to figure out which part went wrong.

Thanks for the great work for magit and also magithub.