### PR TITLE
allow to disable magithub by default

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -104,9 +104,18 @@ created automatically."
     (magit-refresh))
   (message "Magithub is now disabled in this repository"))
 
+(defcustom magithub-enabled-by-default t
+  "Non-nil if Magithub is enabled by default."
+  :group 'magithub
+  :type 'boolean)
+
 (defun magithub-enabled-p ()
   "Returns non-nil when Magithub is enabled for this repository."
-  (and (member (magit-get "magithub" "enabled") '("yes" "true" nil)) t))
+  (let ((enabled (magit-get "magithub" "enabled")))
+    (cond
+     ((string= enabled "yes") t)
+     ((string= enabled "no") nil)
+     (t magithub-enabled-by-default))))
 
 (defun magithub-enabled-toggle ()
   "Toggle Magithub integration."


### PR DESCRIPTION
Currently, magithub is enabled by default for all repositories, unless I explicitly disable for each repo. This PR simply introduces a custom variable `magithub-enabled-by-default` allowing to disable magithub by default, and modifies `magithub-enabled-p` to take it into account.