### PR TITLE
Add support for ssh:// urls

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -578,9 +578,11 @@ URL may be of several different formats:
            (and (string-match
                  ;; https://github.com/vermiculus/magithub.git
                  ;; git://github.com/vermiculus/magithub.git
+                 ;; ssh://git@github.com/vermiculus/magithub
                  ;; git+ssh://github.com/vermiculus/magithub.git
                  (rx bol
                      (or (seq "http" (? "s"))
+                         (seq "ssh")
                          (seq "git" (? "+ssh")))
                      "://"
                      (group (+? any)) ;domain -- github.com

--- a/test/magithub-test.el
+++ b/test/magithub-test.el
@@ -28,7 +28,8 @@
                 (name . "magithub"))))
     (should (equal repo (magithub--url->repo "git@github.com:vermiculus/magithub.git")))
     (should (equal repo (magithub--url->repo "git@github.com:vermiculus/magithub")))
-    (should (equal repo (magithub--url->repo "git+ssh://github.com/vermiculus/magithub")))))
+    (should (equal repo (magithub--url->repo "git+ssh://github.com/vermiculus/magithub")))
+    (should (equal repo (magithub--url->repo "ssh://git@github.com/vermiculus/magithub")))))
 
 (ert-deftest magithub-test-source-repo ()
   "Test basic API functionality.


### PR DESCRIPTION
I found this necessary because [`ghq`](https://github.com/motemen/ghq)
uses ssh:// urls for private repositories