### PR TITLE
Prevent word wrapping lines which will be truncated later

### DIFF
--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -260,6 +260,7 @@ Each function takes two arguments:
     (let* ((label-string (format fmt "Preview:"))
            (label-len (length label-string))
            (prefix (make-string label-len ?\ ))
+           (max-lines 4)
            did-cut)
       (insert label-string
               (if (or (null .body) (string= .body ""))
@@ -267,11 +268,18 @@ Each function takes two arguments:
                 (concat
                  (s-trim
                   (with-temp-buffer
-                    (insert (s-word-wrap (- fill-column label-len) .body))
+                    (insert (s-word-wrap
+                             (- fill-column label-len)
+                             ;; Truncate string to longest possible wrapped
+                             ;; string before wrapping it (peformance)
+                             (substring .body
+                                        0
+                                        (min (* fill-column max-lines)
+                                             (length .body)))))
                     (goto-char 0)
                     (let ((lines 0))
                       (while (and (not (eobp))
-                                  (< (setq lines (1+ lines)) 4))
+                                  (< (setq lines (1+ lines)) max-lines))
                         (insert prefix)
                         (forward-line))
                       (unless (= (point) (point-max))


### PR DESCRIPTION
See #152.

This is the first thing I noticed (the most obvious fix), but it's far from the biggest improvement. I tried taking a look at the bigger issue, but I dove really deep into macros so that might take some more time. I'm suspecting a 'catch' in a magit macro, but that's going to take a longer time to deal with.

This change reduces my `magit-status` on `qutebrowser/qutebrowser` from 4 seconds to 3, so not a huge improvement, but it is measurable. There is one possible regression in this, though.

Previously, the trim would always trim at 4 lines, regardless of input. Now, there is an edge case where if any of the first few lines is long:

```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
a
a
a
```
The line will be truncated early. Do you think that's acceptible? I don't think it makes too much of a difference, and all the other cases should be the same.

Also, I'm assuming this should go on `develop`, let me know if that's not the case (it dosen't conflict when cherry picking it to master).