### PR TITLE
Fix broken autoload for magit-dispatch-popup

### DIFF
--- a/magithub.el
+++ b/magithub.el
@@ -57,7 +57,7 @@
 (require 'magithub-orgs)
 (require 'magithub-dash)
 
-;;;###autoload
+;;;###autoload (autoload 'magithub-dispatch-popup "magithub" nil t)
 (magit-define-popup magithub-dispatch-popup
   "Popup console for dispatching other Magithub popups."
   'magithub-commands


### PR DESCRIPTION
I'm not sure if this will fix it, but it seems like it will.

I pulled from the [documentation](http://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html), and [this example autload](https://github.com/magit/magit/blob/master/lisp/magit.el#L205) for the same type of macro.

From the documentation

>If you write a function definition with an unusual macro that is not one of the known and recognized function definition methods, use of an ordinary magic autoload comment would copy the whole definition into loaddefs.el. That is not desirable. You can put the desired autoload call into loaddefs.el instead by writing this:

     ;;;###autoload (autoload 'foo "myfile")
     (mydefunmacro foo
       ...)

Closes #161 