### PR TITLE
Avoid error when refresh and cursor is on an issue or PR

### DIFF
--- a/magithub-issue-view.el
+++ b/magithub-issue-view.el
@@ -62,7 +62,7 @@
       (setq-local magithub-issue
                   (magithub-issue magithub-repo magithub-issue))
       (magithub-issue-comments magithub-issue)))
-  (let ((magit-refresh-args (list magithub-issue)))
+  (let ((magit-refresh-args (and magithub-issue (list magithub-issue))))
     (magit-refresh))
   (message "refreshed"))
 


### PR DESCRIPTION
Avoid the following error mesage when refreshing magit buffer:
Wrong number of arguments: (0 . 0), 1

* magithub-issue-view.el:
(magithub-issue-view-refresh): add check for magithub-issue.

This refer to [message](https://github.com/vermiculus/magithub/issues/166#issuecomment-345469843) in PR #166  