### PR TITLE
Fix issue section face

### DIFF
--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -511,7 +511,7 @@ buffer."
     `(when-let ((,sym-filtered (magithub-filter-all ,filters ,list)))
        (magit-insert-section ,spec
          (insert (format "%s%s:"
-                         (propertize ,title 'face 'magit-header-line)
+                         (propertize ,title 'face 'magit-section-heading)
                          (if ,filters
                              (propertize " (filtered)" 'face 'magit-dimmed)
                            "")))


### PR DESCRIPTION
I think what you really want is `magit-section-heading`, since we are rendering section title not header line, though `magit-header-line` is the same as it by default.

This bothers me because the theme I'm using sets `magit-header-line` to bold.