### PR TITLE
Add thing-at-point support for several `github-*' symbols

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -11,6 +11,17 @@
 * New Features
 - Browse commits by using =w= on a commit section.
 - ~magithub-feature-autoinject~ can now take a list of features to load.
+- Many symbols are now supported by ~thing-at-point~:
+  - =github-user=
+  - =github-issue=
+  - =github-label=
+  - =github-comment=
+  - =github-repository=
+  - =github-pull-request=
+  - =github-notification=
+  These symbols should allow other GitHub-sensitive packages to use
+  the work Magithub has already done without depending on Magithub
+  directly.  [[PR:201]]
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the

--- a/magithub-comment.el
+++ b/magithub-comment.el
@@ -26,6 +26,7 @@
 
 (require 'magit)
 (require 'markdown-mode)
+(require 'thingatpt)
 
 (require 'magithub-core)
 (require 'magithub-repo)
@@ -44,7 +45,7 @@
     m))
 
 (defun magithub-comment-browse (comment)
-  (interactive (list (magithub-thing-at-point 'comment)))
+  (interactive (list (thing-at-point 'github-comment)))
   (unless comment
     (user-error "No comment found"))
   (let-alist comment
@@ -52,7 +53,7 @@
 
 (declare-function face-remap-remove-relative "face-remap.el" (cookie))
 (defun magithub-comment-delete (comment)
-  (interactive (list (magithub-thing-at-point 'comment)))
+  (interactive (list (thing-at-point 'github-comment)))
   (unless comment
     (user-error "No comment found"))
   (let ((repo (magithub-comment-source-repo comment))
@@ -94,8 +95,8 @@
 
 (defun magithub-comment-draft-save (repo issue comment)
   "Save a draft reply to REPO/ISSUE as COMMENT."
-  (interactive (list (magithub-thing-at-point 'repo)
-                     (magithub-thing-at-point 'issue)
+  (interactive (list (thing-at-point 'github-repository)
+                     (thing-at-point 'github-issue)
                      (buffer-string)))
   (make-directory (magithub-repo-data-dir repo) t)
   (with-temp-buffer
@@ -151,7 +152,7 @@ the comment; see `magithub-comment-view' and
 
 (defun magithub-comment-view (comment)
   "View COMMENT in a new buffer."
-  (interactive (list (magithub-thing-at-point 'comment)))
+  (interactive (list (thing-at-point 'github-comment)))
   (let ((prev (current-buffer)))
     (with-current-buffer (get-buffer-create "*comment*")
       (magithub-gfm-view-mode)
@@ -228,9 +229,9 @@ will deleted.
 
 If ISSUE is not provided, it will be determined from context or
 from COMMENT."
-  (interactive (list (magithub-thing-at-point 'comment)
+  (interactive (list (thing-at-point 'github-comment)
                      current-prefix-arg
-                     (magithub-thing-at-point 'issue)))
+                     (thing-at-point 'github-issue)))
   (let-alist comment
     (magithub-comment-new
      (or issue (magithub-request (ghubp-follow-get .issue_url)))
@@ -254,16 +255,16 @@ COMMENT is the text of the new comment.
 
 REPO is an optional repo object; it will be deduced from ISSUE if
 not provided."
-  (interactive (list (magithub-thing-at-point 'issue)
+  (interactive (list (thing-at-point 'github-issue)
                      (save-restriction
                        (widen)
                        (buffer-substring-no-properties (point-min) (point-max)))
-                     (magithub-thing-at-point 'repo)))
+                     (thing-at-point 'github-repository)))
   (unless issue
     (user-error "No issue provided"))
   (setq repo (or repo
                  (magithub-issue-repo issue)
-                 (magithub-thing-at-point 'repo)))
+                 (thing-at-point 'github-repository)))
   (unless repo
     (user-error "No repo detected"))
   ;; all required args provided

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -29,6 +29,7 @@
 (require 'ghub+)
 (require 'cl-lib)
 (require 'magit)
+(require 'thingatpt)
 
 (require 'magithub-core)
 (require 'magithub-user)
@@ -157,19 +158,19 @@ default."
                              t default))
 (defun magithub-issue-completing-read-issues (&optional default)
   "Read an issue in the minibuffer with completion."
-  (interactive (list (magithub-thing-at-point 'issue)))
+  (interactive (list (thing-at-point 'github-issue)))
   (magithub-issue--completing-read
    "Issue: " default (list #'magithub-issue--issue-is-issue-p)))
 (defun magithub-issue-completing-read-pull-requests (&optional default)
   "Read a pull request in the minibuffer with completion."
-  (interactive (list (magithub-thing-at-point 'pull-request)))
+  (interactive (list (thing-at-point 'github-pull-request)))
   (magithub-issue--completing-read
    "Pull Request: " default (list #'magithub-issue--issue-is-pull-p)))
 (defun magithub-interactive-issue ()
-  (or (magithub-thing-at-point 'issue)
+  (or (thing-at-point 'github-issue)
       (magithub-issue-completing-read-issues)))
 (defun magithub-interactive-pull-request ()
-  (or (magithub-thing-at-point 'pull-request)
+  (or (thing-at-point 'github-pull-request)
       (magithub-issue-completing-read-pull-requests)))
 
 (defun magithub-issue-find (number)
@@ -467,8 +468,8 @@ buffer."
   (interactive
    (when (magithub-verify-manage-labels t)
      (let* ((fmt (lambda (l) (alist-get 'name l)))
-            (issue (or (magithub-thing-at-point 'issue)
-                       (magithub-thing-at-point 'pull-request)))
+            (issue (or (thing-at-point 'github-issue)
+                       (thing-at-point 'github-pull-request)))
             (current-labels (alist-get 'labels issue))
             (to-remove (magithub--completing-read-multiple
                         "Remove labels: " current-labels fmt)))
@@ -597,7 +598,7 @@ Interactively, this finds the issue at point."
   "Checkout PULL-REQUEST.
 PULL-REQUEST is the full object; not just the issue subset."
   (interactive (list
-                (let ((pr (or (magithub-thing-at-point 'pull-request)
+                (let ((pr (or (thing-at-point 'github-pull-request)
                               (magithub-issue-completing-read-pull-requests))))
                   (magithub-request
                    (ghubp-get-repos-owner-repo-pulls-number

--- a/magithub-label.el
+++ b/magithub-label.el
@@ -1,4 +1,6 @@
+(require 'thingatpt)
 (require 'ghub+)
+
 (require 'magithub-core)
 
 (defvar magit-magithub-label-section-map
@@ -42,7 +44,7 @@ prompted for again."
   "Visit LABEL with `browse-url'.
 In the future, this will likely be replaced with a search on
 issues and pull requests with the label LABEL."
-  (interactive (list (magithub-thing-at-point 'label)))
+  (interactive (list (thing-at-point 'github-label)))
   (unless label
     (user-error "No label found at point to browse"))
   (unless (string= (ghubp-host) ghub-default-host)
@@ -79,7 +81,7 @@ from `magithub-label'.  Customize that to affect all labels."
 (defun magithub-label-color-replace (label new-color)
   "For LABEL, define a NEW-COLOR to use in the buffer."
   (interactive
-   (list (magithub-thing-at-point 'label)
+   (list (thing-at-point 'github-label)
          (magithub-core-color-completing-read "Replace label color: ")))
   (let ((label-color (concat "#" (alist-get 'color label))))
     (if-let ((cell (assoc-string label-color magithub-label-color-replacement-alist)))
@@ -100,8 +102,8 @@ from `magithub-label'.  Customize that to affect all labels."
 (defun magithub-label-remove (issue label)
   "From ISSUE, remove LABEL."
   (interactive (and (magithub-label--verify-manage)
-                    (list (magithub-thing-at-point 'issue)
-                          (magithub-thing-at-point 'label))))
+                    (list (thing-at-point 'github-issue)
+                          (thing-at-point 'github-label))))
   (unless issue
     (user-error "No issue here"))
   (unless label
@@ -117,7 +119,7 @@ from `magithub-label'.  Customize that to affect all labels."
 
 (defun magithub-label-add (issue labels)
   "To ISSUE, add LABELS."
-  (interactive (list (magithub-thing-at-point 'issue)
+  (interactive (list (thing-at-point 'github-issue)
                      (magithub-label-read-labels "Add labels: ")))
   (if (not (and issue labels))
       (user-error "No issue/labels")

--- a/magithub-notification.el
+++ b/magithub-notification.el
@@ -24,6 +24,8 @@
 
 ;;; Code:
 
+(require 'thingatpt)
+
 (require 'magithub-issue-view)
 
 (defvar magit-magithub-notification-section-map
@@ -103,7 +105,7 @@ get a more verbose explanation."
 (defalias 'magithub-notification-visit #'magithub-notification-browse)
 (defun magithub-notification-browse (notification)
   "Visits the URL pointed to by NOTIFICATION."
-  (interactive (list (magithub-thing-at-point 'notification)))
+  (interactive (list (thing-at-point 'github-notification)))
   (if notification
       (let-alist notification
         (cond

--- a/magithub-repo.el
+++ b/magithub-repo.el
@@ -25,6 +25,8 @@
 ;;; Code:
 
 (require 'magit)
+(require 'thingatpt)
+
 (require 'magithub-core)
 
 (defvar-local magithub-repo nil
@@ -37,7 +39,7 @@
     m))
 
 (defun magithub-repo-browse (repo)
-  (interactive (list (magithub-thing-at-point 'repo)))
+  (interactive (list (thing-at-point 'github-repo)))
   (unless repo
     (user-error "No repository found at point"))
   (let-alist repo

--- a/magithub-user.el
+++ b/magithub-user.el
@@ -26,6 +26,7 @@
 
 (require 'ghub+)
 (require 'cl-lib)
+(require 'thingatpt)
 
 (require 'magithub-core)
 
@@ -87,8 +88,8 @@
 
 (defun magithub-assignee-remove (issue user)
   (interactive (when (magithub-assignee--verify-manage)
-                 (list (magithub-thing-at-point 'issue)
-                       (magithub-thing-at-point 'user))))
+                 (list (thing-at-point 'github-issue)
+                       (thing-at-point 'github-user))))
   (let-alist `((repo . ,(magithub-issue-repo issue))
                (issue . ,issue)
                (user . ,user))
@@ -128,14 +129,14 @@
 (defalias 'magithub-user-visit #'magithub-user-browse)
 (defun magithub-user-browse (user)
   "Open USER on Github."
-  (interactive (list (magithub-thing-at-point 'user)))
+  (interactive (list (thing-at-point 'github-user)))
   (if user
       (browse-url (alist-get 'html_url user))
     (user-error "No user here")))
 
 (defun magithub-user-email (user)
   "Email USER."
-  (interactive (list (magithub-thing-at-point 'user)))
+  (interactive (list (thing-at-point 'github-user)))
   (when (and (string= (alist-get 'login (magithub-user-me))
                       (alist-get 'login user))
              (not (y-or-n-p "Email yourself? ")))


### PR DESCRIPTION
This should make it possible for more packages to work with Magithub without really 'knowing' about it.

* Remove function `magithub-thing-at-point` and replace with a private implementation of the same logic.
* Defines several thingatpt-enabled symbols:
   - `github-user`
   - `github-issue`
   - `github-label`
   - `github-comment`
   - `github-repository`
   - `github-pull-request`
   - `github-notification`

  Each of these symbols uses the implementation of `magithub-thing-at-point` (now called `magithub--section-value-at-point`) to get the relevant section data.