### PR TITLE
Fix Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-#language: emacs-lisp
-language: python
-sudo: false
+language: emacs-lisp
+sudo: required
+dist: trusty
 cache:
 - directories:
   - "$HOME/emacs"


### PR DESCRIPTION
Start using `sudo: required` to workaround a Travis issue.

See travis-ci/travis-ci#9061 for details.

---

Also, sorry about the commit-based pings to that Travis issue -- GitHub is trying to be smart and is ignoring my attempt to *avoid* that... Despite what GitHub shows, here is what the commit message *actually* looked like:

``` text
Start using `sudo: required' to workaround a transient Travis issue.
See `https://github.com/travis-ci/travis-ci/issues/9061' for details.
```

I didn't expect a URL to be translated to an issue reference; I originally thought it *had* to be `[user/repo]#num`.  Apparently not.  ☹️