### PR TITLE
Replace soon-to-be-deprecated when-let

### DIFF
--- a/magithub-ci.el
+++ b/magithub-ci.el
@@ -117,7 +117,7 @@ It may fail if the fork has multiple branches named BRANCH."
 
 (defun magithub-pull-request-branch->pr--gitconfig (branch)
   "Gets a pull request object from branch.BRANCH.magithub.sourcePR"
-  (when-let ((source (magit-get "branch" branch "magithub" "sourcePR")))
+  (when-let* ((source (magit-get "branch" branch "magithub" "sourcePR")))
     (magithub-pull-request (magithub-repo) (string-to-number source))))
 
 (defun magithub-ci-status--get-default-ref (&optional branch)
@@ -132,7 +132,7 @@ remote counterpart."
                      (with-demoted-errors "Error: %S"
                        (magithub-pull-request-branch->pr--ghub branch))))))
       (let-alist pull-request .head.sha)
-    (when-let ((push-branch (magit-get-push-branch branch)))
+    (when-let* ((push-branch (magit-get-push-branch branch)))
       (when (magit-branch-p push-branch)
         (cdr (magit-split-branch-name push-branch))))))
 

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -38,6 +38,12 @@
 
 (require 'magithub-faces)
 
+;; Compatibility
+(eval-and-compile
+  (when (version< emacs-version "26")
+    (defalias 'if-let* #'if-let)
+    (defalias 'when-let* #'when-let)))
+
 (defconst magithub-github-token-scopes '(repo user notifications)
   "The authentication scopes Magithub requests.")
 
@@ -469,7 +475,7 @@ See `magithub--api-offline-reason'."
 ;;; Repository parsing
 (defun magithub-github-repository-p ()
   "Non-nil if \"origin\" points to GitHub or a whitelisted domain."
-  (when-let ((origin (magit-get "remote" "origin" "url")))
+  (when-let* ((origin (magit-get "remote" "origin" "url")))
     (-some? (lambda (domain) (s-contains? domain origin))
             (cons "github.com" (magit-get-all "hub" "host")))))
 
@@ -550,7 +556,7 @@ included in the returned object."
 (defun magithub-repo (&optional sparse-repo)
   "Turn SPARSE-REPO into a full repository object.
 If SPARSE-REPO is null, the current context is used."
-  (when-let ((sparse-repo (or sparse-repo (magithub-source--sparse-repo))))
+  (when-let* ((sparse-repo (or sparse-repo (magithub-source--sparse-repo))))
     (or (magithub-cache :repo-demographics
           `(condition-case e
                (or (magithub-request
@@ -962,7 +968,7 @@ this function: `github-user', `github-issue', `github-label',
 (put 'github-pull-request 'thing-at-point
      (lambda ()
        (or (magithub--section-value-at-point 'pull-request)
-           (when-let ((issue (thing-at-point 'github-issue)))
+           (when-let* ((issue (thing-at-point 'github-issue)))
              (and
               (magithub-issue--issue-is-pull-p issue)
               (magithub-cache :issues
@@ -988,7 +994,7 @@ of a signal (e.g., for interactive forms)."
   "In GitHub repositories, configure `bug-reference-mode'."
   (interactive)
   (when (magithub-usable-p)
-    (when-let ((repo (magithub-repo)))
+    (when-let* ((repo (magithub-repo)))
       (bug-reference-mode 1)
       (setq-local bug-reference-bug-regexp "#\\(?2:[0-9]+\\)")
       (setq-local bug-reference-url-format
@@ -1168,7 +1174,7 @@ Use directly at your own peril; this is intended for use with
 (defun magithub-commit-browse (rev)
   "Browse REV on GitHub.
 Interactively, this is the commit at point."
-  (interactive (list (or (when-let ((rev (magit-rev-verify (oref (magit-current-section) value))))
+  (interactive (list (or (when-let* ((rev (magit-rev-verify (oref (magit-current-section) value))))
                            rev)
                          (thing-at-point 'git-revision))))
   (if-let ((parsed (magit-rev-parse rev)))

--- a/magithub-dash.el
+++ b/magithub-dash.el
@@ -112,7 +112,7 @@ See also `magithub-dash-headers-hook'."
 (defun magithub-dash-insert-ratelimit-header ()
   "If API requests are being rate-limited, insert relevant information."
   (magithub-request
-   (when-let ((ratelimit (ghubp-ratelimit)))
+   (when-let* ((ratelimit (ghubp-ratelimit)))
      (when (time-less-p (alist-get 'reset ratelimit) (current-time))
        (ghub-get "/rate_limit" nil :auth 'magithub)))
    (let-alist (ghubp-ratelimit)
@@ -176,7 +176,7 @@ will be used."
    (setq issues (or issues (magithub-cache :issues `(magithub-request
                                                      (ghubp-get-issues))))
          title (or title "Issues Assigned to Me"))
-   (when-let ((user-repo-issue-buckets
+   (when-let* ((user-repo-issue-buckets
                ;; bucket by user then by repo
                (magithub-core-bucket-multi issues
                  #'magithub-issue-repo

--- a/magithub-issue-post.el
+++ b/magithub-issue-post.el
@@ -14,7 +14,7 @@
     (when (s-blank-p (alist-get 'title issue))
       (user-error "Title is required"))
     (when (magithub-repo-push-p repo)
-      (when-let ((issue-labels (magithub-label-read-labels "Labels: ")))
+      (when-let* ((issue-labels (magithub-label-read-labels "Labels: ")))
         (push (cons 'labels issue-labels) issue)))
     (when (yes-or-no-p "Are you sure you want to submit this issue? ")
       (let ((issue (magithub-request
@@ -42,7 +42,7 @@
 
 (defun magithub-issue--template-text (template)
   (with-temp-buffer
-    (when-let ((template (magithub-issue--template-find template)))
+    (when-let* ((template (magithub-issue--template-find template)))
       (insert-file-contents template)
       (buffer-string))))
 

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -505,7 +505,7 @@ buffer."
 (defmacro magithub-issue--insert-generic-section
     (spec title list filters)
   (let ((sym-filtered (cl-gensym)))
-    `(when-let ((,sym-filtered (magithub-filter-all ,filters ,list)))
+    `(when-let* ((,sym-filtered (magithub-filter-all ,filters ,list)))
        (magit-insert-section ,spec
          (insert (format "%s%s:"
                          (propertize ,title 'face 'magit-section-heading)
@@ -543,7 +543,7 @@ Interactively, this finds the pull request at point."
 (defun magithub-issue--browse (issue-or-pr)
   "Visits ISSUE-OR-PR in the browser.
 Interactively, this finds the issue at point."
-  (when-let ((url (alist-get 'html_url issue-or-pr)))
+  (when-let* ((url (alist-get 'html_url issue-or-pr)))
     (browse-url url)))
 
 (defun magithub-repolist-column-issue (_id)

--- a/magithub-user.el
+++ b/magithub-user.el
@@ -111,7 +111,7 @@
              (concat prompt
                      (if new-username (format " ['%s' not found]" new-username)))
              (alist-get 'login default-user)))
-      (when-let ((try (condition-case _
+      (when-let* ((try (condition-case _
                           (magithub-request
                            (ghubp-get-users-username `((login . ,new-username))))
                         (ghub-404 nil))))


### PR DESCRIPTION
`when-let` is deprecated in Emacs 26. Unfortunately, it is replaced by `when-let*` which does not exist in Emacs 25. This library was already using dash, so I replaced them with `-when-let*`.

Alternatively, something like [this](https://github.com/raxod502/el-patch/commit/c46873df05526655d9f4c275cb4b479713f896ab#diff-b7d90f21b49f31314f7e9f1cd63fa8fcR53) could be done, but I didn't think be a good idea to add that to every file.