### PR TITLE
Don't cache commit object when browsing

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -12,7 +12,9 @@
   more details in 'New Features'.  [[PR:204]]
 
 * New Features
-- Browse commits by using =w= on a commit section.
+- Browse commits by using =w= on a commit section.  If the current
+  section's value cannot be understood as a valid commit, use the
+  =git-revision= at point.
 - ~magithub-feature-autoinject~ can now take a list of features to load.
 - Many symbols are now supported by ~thing-at-point~:
   - =github-user=
@@ -33,8 +35,6 @@
   interface that supports submitting, cancelling, and saving drafts to
   finish later.  [[PR:204]]
 - You can now edit comments using =e= on a comment section.  [[PR:206]]
-- ~magithub-commit-browse~ will now use the =git-revision= at point if the
-  current section's value cannot be understood as a valid commit.
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -1171,11 +1171,12 @@ Interactively, this is the commit at point."
                            rev)
                          (thing-at-point 'git-revision))))
   (if-let ((parsed (magit-rev-parse rev)))
-      (let-alist (car (magithub-cache :commit
-                        `(ghubp-get-repos-owner-repo-commits
-                             ',(magithub-repo) nil
-                           :sha ,parsed)))
-        (browse-url .html_url))
+      (if-let ((commits (ghubp-get-repos-owner-repo-commits
+                            (magithub-repo) nil
+                          :sha parsed)))
+          (let-alist (car commits)
+            (browse-url .html_url))
+        (user-error "No commit %s on remote" parsed))
     (error "Could not parse %S" rev)))
 
 (defun magithub-add-thing ()


### PR DESCRIPTION
Also don't freak out if the commit can't be found on the remote.