### PR TITLE
Make it a little easier to use Magithub from other packages

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -43,6 +43,8 @@
   ~magit-log~ shows you the changes you want to merge.  [[PR:239]]
 - Headers in issue-view mode are now easier to naviagte.  [[PR:250]]
 - Notifications are marked as read when visited in Emacs.  [[PR:252]]
+- ~magithub-repo~ can now take a string of the form =user/repo=.  This is
+  helpful when writing other code that uses Magithub functionality.  [[PR:253]]
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the


### PR DESCRIPTION
`magithub-repo` can now take a repository *name* instead of a full/sparse repository *object*.  This means I can do fancy things like this:

``` emacs-lisp
(magithub-repo "vermiculus/magithub")
```

and `magithub-repo` will recognize this as a valid repository identifier and piece it out into a more traditional `magithub-repo` call.

This comes in handy when using functions that require a repository context.  Something like this...

``` emacs-lisp
(magithub-issue-new (magithub-repo "your/project"))
```

...can easily be a good way to gather bug reports inside emacs.