### PR TITLE
Drop restriction on cloning while current directory is a repo

### DIFF
--- a/magithub.el
+++ b/magithub.el
@@ -224,20 +224,17 @@ Banned inside existing GitHub repositories if
 `magithub-clone-default-directory' is nil.
 
 See also `magithub-preferred-remote-method'."
-  (interactive (if (and (not magithub-clone-default-directory)
-                        (magithub-github-repository-p))
-                   (user-error "Already in a GitHub repo")
-                 (let* ((repo (magithub-clone--get-repo))
-                        (repo (or (magithub-request
-                                   (ghubp-get-repos-owner-repo repo))
-                                  (let-alist repo
-                                    (user-error "Repository %s/%s does not exist"
-                                                .owner.login .name))))
-                        (dirname (read-directory-name
-                                  "Destination: "
-                                  magithub-clone-default-directory
-                                  (alist-get 'name repo))))
-                   (list repo dirname))))
+  (interactive (let* ((repo (magithub-clone--get-repo))
+                      (repo (or (magithub-request
+                                 (ghubp-get-repos-owner-repo repo))
+                                (let-alist repo
+                                  (user-error "Repository %s/%s does not exist"
+                                              .owner.login .name))))
+                      (dirname (read-directory-name
+                                "Destination: "
+                                magithub-clone-default-directory
+                                (alist-get 'name repo))))
+                 (list repo dirname)))
   ;; Argument validation
   (unless (called-interactively-p 'any)
     (unless (setq repo (magithub-request


### PR DESCRIPTION
It's nonsensical to stop the user from cloning a repo if the clone default directory is unset and the current directory is a repo, since whether or not the default directory is set, the user must choose where to clone the repo.

Instead, trusting the user to pay attention to what they're doing is fine here.

This is related to #236.