### PR TITLE
Add support for completion of issue numbers in relevant buffers

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -85,6 +85,10 @@
   ~magithub-confirm-set-default-behavior~ .  [[PR:268]]
 - Use default branch of the repository as BASE if there's no upstream
   for the current branch.  [[PR:269]]
+- Completion of issue numbers, e.g. "#123" is supported in edit and
+  commit message buffers via the standard ~completion-at-point~
+  mechanism, and therefore also via ~company~'s ~capf~ backend.  Call
+  ~magithub-completion-enable-everywhere~ to enable.  [[PR:263]]
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -50,7 +50,7 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
               (when (string-prefix-p prefix n)
                 (set-text-properties 0 (length n) (list :issue i) n)
                 (push n completions)))))
-        (list start end (sort completions 'string<)
+        (list start end (sort completions #'string<)
               :exclusive 'no
               :company-docsig (lambda (c)
                                 (let-alist (get-text-property 0 :issue c)

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -29,7 +29,9 @@
 ;;; Code:
 
 
-(require 'magithub)
+(require 'magithub-settings)
+(require 'magithub-issue)
+(require 'magithub-edit-mode)
 
 
 ;;;###autoload

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -1,0 +1,83 @@
+;;; magithub-completion.el --- Completion using info provided by magithub  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018  Steve Purcell
+
+;; Author: Steve Purcell <steve@sanityinc.com>
+;; Keywords: convenience
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides `completion-at-point' functions which complete issue
+;; numbers etc when they are entered in commit messages.
+
+;; Extended information is attached to completions so that `company'
+;; can access it via the standard `company-capf' backend.
+
+;;; Code:
+
+
+(require 'magithub)
+
+
+;;;###autoload
+(defun magithub-completion-complete-issues ()
+  "A `completion-at-point' function which completes \"#123\" issue references.
+Add this to `completion-at-point-functions' in buffers where you want this to be available."
+  (when (magithub-enabled-p)
+    (when (looking-back "#\\([0-9]*\\)" (- (point) 10))
+      (let ((start (match-beginning 1))
+            (end (match-end 0))
+            (prefix (match-string 1))
+            completions)
+        (dolist (i (magithub--issue-list))
+          (let-alist i
+            (let ((n (number-to-string .number)))
+              (when (string-prefix-p prefix n)
+                (set-text-properties 0 (length n) (list :issue i) n)
+                (push n completions)))))
+        (list start end (sort completions 'string<)
+              :exclusive 'no
+              :company-docsig (lambda (c)
+                                (let-alist (get-text-property 0 :issue c)
+                                  .title))
+              :company-location (lambda (c)
+                                  (magithub-issue-browse (get-text-property 0 :issue c)))
+              :annotation-function (lambda (c)
+                                     (let-alist (get-text-property 0 :issue c)
+                                       .title))
+              :company-doc-buffer (lambda (c)
+                                    (save-window-excursion
+                                      (magithub-issue-visit (get-text-property 0 :issue c))))
+              )))))
+
+
+;;;###autoload
+(defun magithub-completion-enable ()
+  "Enable completion of info from magithub in the current buffer."
+  (add-to-list (make-local-variable 'completion-at-point-functions)
+               'magithub-completion-complete-issues))
+
+;;;###autoload
+(defun magithub-completion-enable-everywhere ()
+  "Enable completion of info from magithub in the current buffer."
+  (interactive)
+  (dolist (hook '(git-commit-setup-hook magithub-edit-mode-hook))
+    (add-hook hook 'magithub-completion-enable)))
+
+
+
+(provide 'magithub-completion)
+;;; magithub-completion.el ends here

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -55,8 +55,6 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
               :company-docsig (lambda (c)
                                 (let-alist (get-text-property 0 :issue c)
                                   .title))
-              :company-location (lambda (c)
-                                  (magithub-issue-browse (get-text-property 0 :issue c)))
               :annotation-function (lambda (c)
                                      (let-alist (get-text-property 0 :issue c)
                                        .title))

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -31,7 +31,6 @@
 
 (require 'magithub-settings)
 (require 'magithub-issue)
-(require 'magithub-edit-mode)
 
 
 ;;;###autoload
@@ -69,14 +68,6 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
   "Enable completion of info from magithub in the current buffer."
   (add-to-list (make-local-variable 'completion-at-point-functions)
                'magithub-completion-complete-issues))
-
-;;;###autoload
-(defun magithub-completion-enable-everywhere ()
-  "Enable completion of info from magithub in the current buffer."
-  (interactive)
-  (dolist (hook '(git-commit-setup-hook magithub-edit-mode-hook))
-    (add-hook hook 'magithub-completion-enable)))
-
 
 
 (provide 'magithub-completion)

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -596,6 +596,7 @@ See also `magithub-repo-remotes'."
 (declare-function magithub-maybe-insert-ci-status-header "magithub-ci" ())
 (declare-function magithub-issue--insert-pr-section "magithub-issue" ())
 (declare-function magithub-issue--insert-issue-section "magithub-issue" ())
+(declare-function magithub-completion-enable "magithub-completion" ())
 (defconst magithub-feature-list
   ;; features must only return nil if they fail to install
   `((pull-request-merge . ,(lambda ()
@@ -614,6 +615,11 @@ See also `magithub-repo-remotes'."
                                          #'magithub-maybe-insert-ci-status-header
                                          t)
                                t))
+
+    (completion . ,(lambda ()
+                     (dolist (hook '(git-commit-setup-hook magithub-edit-mode-hook))
+                       (add-hook hook #'magithub-completion-enable))
+                     t))
 
     ;; order is important in this list; pull request section should
     ;; come before issues section by default
@@ -637,6 +643,10 @@ See `magithub-feature-autoinject'.
 
 - `commit-browse'
   Browse commits using \\<magithub-map>\\[magithub-browse-thing].
+
+- `completion'
+  Enable `completion-at-point' support for issue references like
+  \"#123\" where possible.
 
 - `issues-section'
   View issues in the `magit-status' buffer.


### PR DESCRIPTION
This allows completion of `#123` issue numbers etc. with vanilla Emacs' `completion-at-point` mechanism, with extended completion attributes so that `company`'s completion-at-point backend can show further information about candidates.

I was going to publish this as a separate little package, but it arguably belongs in `magithub` directly. In its current form, there is no change in default behaviour, i.e. completion is never auto-enabled: this is the more conservative choice, but perhaps this functionality warrants loading via the `magithub-features` mechanism.

Thoughts for future enhancement:
- It'd be nice to complete `@user` patterns from known user names (relates to discussion of caching users in #262).
- Completing issues in other repos would be useful.
- Patterns such as "PR 123" / "pull request 123" / "issue 123" should perhaps also be completed.