### PR TITLE
Use default branch of the repository as BASE if there's no upstream for the current branch

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -83,6 +83,8 @@
 - Confirmation messages can now be skipped (or the default question
   behavior otherwise altered) using =git config= properties.  See
   ~magithub-confirm-set-default-behavior~ .  [[PR:268]]
+- Use default branch of the repository as BASE if there's no upstream
+  for the current branch.  [[PR:269]]
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the

--- a/magithub-issue-post.el
+++ b/magithub-issue-post.el
@@ -116,8 +116,9 @@ See also URL
                         branch))
          (base        (magithub-remote-branches-choose
                        "Base branch" base-remote
-                       (when on-this-remote
-                         (magit-get-upstream-branch head-branch))))
+                       (or (and on-this-remote
+                                (magit-get-upstream-branch head-branch))
+                           (let-alist parent-repo .default_branch))))
          (user+head   (format "%s:%s" this-repo-owner head-branch)))
     (when (magithub-request (ghubp-get-repos-owner-repo-pulls parent-repo nil :head user+head))
       (user-error "A pull request on %s already exists for head \"%s\""


### PR DESCRIPTION
From #266.