### PR TITLE
Set default confirmation responses interactively

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -82,8 +82,10 @@
   endpoint is not what I thought it would be.)  [[PR:256]]
 - Confirmation messages can now be skipped (or the default question
   behavior otherwise altered) using =git config= properties.  See
-  ~magithub-confirm-set-default-behavior~ .  [[PR:268]]
-- Use default branch of the repository as BASE if there's no upstream
+  ~magithub-confirm-set-default-behavior~ or configure your settings
+  locally (or globally) interactively when they're asked.  [[PR:268]]
+  [[PR:270]]
+- Use default branch of the repository as =BASE= if there's no upstream
   for the current branch.  [[PR:269]]
 - Completion of issue numbers, e.g. "#123" is supported in edit and
   commit message buffers via the standard ~completion-at-point~

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -726,9 +726,22 @@ See /.github/ISSUE_TEMPLATE.md in this repository."
   (interactive)
   (browse-url "https://gitter.im/vermiculus/magithub"))
 
-(defun magithub-error (err-message tag &optional trace)
-  "Report a Magithub error."
-  (setq trace (or trace (with-output-to-string (backtrace))))
+(defun magithub-error (err-message &optional tag trace)
+  "Report a Magithub error.
+
+ERR-MESSAGE is a string to be shown to the user.
+
+TAG, if provided, is a user-friendly description of the error.
+It defaults to ERR-MESSAGE.
+
+If TRACE is provided, it should be an appropriate backtrace to
+describe the error.  If not provided, it is retrieved."
+  (unless (stringp err-message)
+    ;; just in case.  it'd be embarassing if the bug-reporter was
+    ;; perceived as buggy
+    (setq err-message (prin1-to-string err-message)))
+  (setq trace (or trace (with-output-to-string (backtrace)))
+        tag (or tag err-message))
   (when (magithub-confirm-no-error 'report-error tag)
     (with-current-buffer-window
      (get-buffer-create "*magithub issue*")
@@ -739,6 +752,8 @@ See /.github/ISSUE_TEMPLATE.md in this repository."
        (format
         "## Automated error report
 
+%s
+
 ### Description
 
 %s
@@ -748,6 +763,7 @@ See /.github/ISSUE_TEMPLATE.md in this repository."
 ```
 %s```
 "
+        err-message
         (read-string "Briefly describe what you were doing: ")
         trace))))
     (magithub--meta-new-issue))


### PR DESCRIPTION
This one was actually pretty difficult. Two new functions are introduced: `magithub-confirm-{yes-or-no,y-or-n}-p`. These functions are like their standard counterparts, but they're also able to save the relevant git variables. Options for this behavior (don't save, save locally, save globally) are cycled when the prompt is active with `universal-prefix-argument` (aka `C-u`).

Note that the `C-u` is hard-coded for `magithub-confirm-y-or-n-p`; keymaps don't work the same way in this context. If anybody has a workaround, I'd be happy to merge it 😄 

Related to discussions in #264.