### PR TITLE
Use a better check to detect pull requests of a single commit

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -113,3 +113,8 @@
 - Submitting pull requests to other repositories in some scenarios
   should now be fixed.  [[PR:272]]
 - ~magithub-clone~ now correctly provides a default destination.  [[PR:273]]
+- ~magithub-pull-request-new~ now uses a better check to test for pull
+  requests of a single commit:  [[PR:274]]
+  #+BEGIN_SRC sh
+    git rev-list --count BASE..
+  #+END_SRC

--- a/magithub-issue-post.el
+++ b/magithub-issue-post.el
@@ -138,8 +138,8 @@ See also URL
   (interactive (let-alist (magithub-pull-request-new-arguments)
                  (magithub-confirm 'pre-submit-pr .user+head (magithub-repo-name .repo) .base)
                  (list .repo .base .fork .head .head-no-user)))
-  (let ((is-single-commit (string= (magit-rev-parse base)
-                                   (magit-rev-parse (format "%s~1" head-no-user)))))
+  (let ((is-single-commit
+         (string= "1" (magit-git-string "rev-list" "--count" (format "%s.." base)))))
     (unless is-single-commit
       (apply #'magit-log (list (format "%s..%s" base head)) (magit-log-arguments)))
     (with-current-buffer


### PR DESCRIPTION
This new check works whether or not `base` and `head` share a simple lineage.