### PR TITLE
Complete user names too

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -87,10 +87,11 @@
   [[PR:270]]
 - Use default branch of the repository as =BASE= if there's no upstream
   for the current branch.  [[PR:269]]
-- Completion of issue numbers, e.g. "#123" is supported in edit and
-  commit message buffers via the standard ~completion-at-point~
-  mechanism, and therefore also via ~company~'s ~capf~ backend.  Call
-  ~magithub-completion-enable-everywhere~ to enable.  [[PR:263]]
+- Completion of issue numbers ("#123"), and user names ("@purcell") is
+  supported in edit and commit message buffers via the standard
+  ~completion-at-point~ mechanism, and therefore also via ~company~'s ~capf~
+  backend.  This is enabled by default in certain buffers via the
+  ~magithub-features~ mechanism.  [[PR:263]], [[PR:278]]
 
 * Bug Fixes
 - In ~magithub-repo~, an API request is no longer made when the

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -47,8 +47,7 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
           (let-alist i
             (let ((n (number-to-string .number)))
               (when (string-prefix-p prefix n)
-                (set-text-properties 0 (length n) (list :issue i) n)
-                (push n completions)))))
+                (push (propertize n :issue i) completions)))))
         (list start end (sort completions #'string<)
               :exclusive 'no
               :company-docsig (lambda (c)
@@ -81,10 +80,8 @@ list of all users who created issues or pull requests."
                     (association (and .author_association
                                       (not (string= "NONE" .author_association))
                                       .author_association)))
-                (set-text-properties 0 (length candidate) (list :user .user) candidate)
-                (set-text-properties 0 (length candidate) (list :association association) candidate)
-                (push candidate completions)))
-            ))
+                (push (propertize candidate :user .user :association association)
+                      completions)))))
         (list start end (sort (cl-remove-duplicates completions :test #'string=) #'string<)
               :exclusive 'no
               :company-docsig (lambda (c) (get-text-property 0 :association c))

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -62,12 +62,43 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
                                       (magithub-issue-visit (get-text-property 0 :issue c))))
               )))))
 
+;;;###autoload
+(defun magithub-completion-complete-users ()
+  "A `completion-at-point' function which completes \"@user\" user references.
+Add this to `completion-at-point-functions' in buffers where you
+want this to be available.  The user list is currently simply the
+list of all users who created issues or pull requests."
+  (when (magithub-enabled-p)
+    (when (looking-back "@\\([_-A-Za-z0-9]*\\)" (- (point) 30))
+      (let ((start (match-beginning 1))
+            (end (match-end 0))
+            (prefix (match-string 1))
+            completions)
+        (dolist (i (magithub--issue-list))
+          (let-alist i
+            (when (string-prefix-p prefix .user.login)
+              (let ((candidate (copy-sequence .user.login))
+                    (association (and .author_association
+                                      (not (string= "NONE" .author_association))
+                                      .author_association)))
+                (set-text-properties 0 (length candidate) (list :user .user) candidate)
+                (set-text-properties 0 (length candidate) (list :association association) candidate)
+                (push candidate completions)))
+            ))
+        (list start end (sort (cl-remove-duplicates completions :test #'string=) #'string<)
+              :exclusive 'no
+              :company-docsig (lambda (c) (get-text-property 0 :association c))
+              :annotation-function (lambda (c) (get-text-property 0 :association c))
+              :company-doc-buffer (lambda (c)
+                                    (save-window-excursion
+                                      (magithub-user-visit (get-text-property 0 :user c))))
+              )))))
 
 ;;;###autoload
 (defun magithub-completion-enable ()
   "Enable completion of info from magithub in the current buffer."
-  (add-to-list (make-local-variable 'completion-at-point-functions)
-               'magithub-completion-complete-issues))
+  (dolist (f '(magithub-completion-complete-issues magithub-completion-complete-users))
+    (add-to-list (make-local-variable 'completion-at-point-functions) f)))
 
 
 (provide 'magithub-completion)

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -58,8 +58,7 @@ Add this to `completion-at-point-functions' in buffers where you want this to be
                                        .title))
               :company-doc-buffer (lambda (c)
                                     (save-window-excursion
-                                      (magithub-issue-visit (get-text-property 0 :issue c))))
-              )))))
+                                      (magithub-issue-visit (get-text-property 0 :issue c)))))))))
 
 ;;;###autoload
 (defun magithub-completion-complete-users ()
@@ -85,11 +84,7 @@ list of all users who created issues or pull requests."
         (list start end (sort (cl-remove-duplicates completions :test #'string=) #'string<)
               :exclusive 'no
               :company-docsig (lambda (c) (get-text-property 0 :association c))
-              :annotation-function (lambda (c) (get-text-property 0 :association c))
-              :company-doc-buffer (lambda (c)
-                                    (save-window-excursion
-                                      (magithub-user-visit (get-text-property 0 :user c))))
-              )))))
+              :annotation-function (lambda (c) (get-text-property 0 :association c)))))))
 
 ;;;###autoload
 (defun magithub-completion-enable ()

--- a/magithub-completion.el
+++ b/magithub-completion.el
@@ -97,8 +97,9 @@ list of all users who created issues or pull requests."
 ;;;###autoload
 (defun magithub-completion-enable ()
   "Enable completion of info from magithub in the current buffer."
+  (make-local-variable 'completion-at-point-functions)
   (dolist (f '(magithub-completion-complete-issues magithub-completion-complete-users))
-    (add-to-list (make-local-variable 'completion-at-point-functions) f)))
+    (add-to-list 'completion-at-point-functions f)))
 
 
 (provide 'magithub-completion)

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -645,8 +645,8 @@ See `magithub-feature-autoinject'.
   Browse commits using \\<magithub-map>\\[magithub-browse-thing].
 
 - `completion'
-  Enable `completion-at-point' support for issue references like
-  \"#123\" where possible.
+  Enable `completion-at-point' support for #issue and @user references
+  where possible.
 
 - `issues-section'
   View issues in the `magit-status' buffer.


### PR DESCRIPTION
This commit adds a second completion-at-point function which completes `@user` references.  This initial version simply grabs all the users who opened issues or pull requests, since this information will be quickly available locally. Finding a better source of user info would be a nice enhancement, but this is already useful in my own projects.