### PR TITLE
Retrieve repo object only when remote points to a repo

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -122,3 +122,5 @@
 - Authenticate correctly when marking notifications as read.  [[PR:277]]
 - Don't call ~magit-get~ in a non-existent directory in ~magithub-clone~.
   [[PR:282]]
+- Pull requests now work in repositories with remotes that point to
+  non-GitHub locations.  [[PR:285]]

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -473,7 +473,8 @@ included in the returned object."
    (magithub-settings-context-remote)))
 
 (defun magithub-repo-from-remote (remote)
-  (magithub-repo (magithub-repo-from-remote--sparse remote)))
+  (when-let* ((repo (magithub-repo-from-remote--sparse remote)))
+    (magithub-repo repo)))
 
 (defun magithub-repo-from-remote--sparse (remote)
   (magithub--url->repo (magit-get "remote" remote "url")))


### PR DESCRIPTION
This should fix #283 and may resolve #195, too.