### PR TITLE
Add some documentation for two-factor auth

### DIFF
--- a/magithub.org
+++ b/magithub.org
@@ -55,8 +55,26 @@ use Magithub.  (As of #107, Magithub will not even attempt go online until
 you're properly authenticated.)
 
 To authenticate, you can simply start using Magithub; Ghub should walk you
-through the authentication process.  (Your token is stored in one of your
-~auth-sources~; see [[https://magit.vc/manual/ghub/How-Ghub-uses-Auth_002dSource.html#How-Ghub-uses-Auth_002dSource][Ghub's manual]] for details.)
+through the authentication process unless you use two-factor authentication.
+(Your token is stored in one of your ~auth-sources~; see [[https://magit.vc/manual/ghub/How-Ghub-uses-Auth_002dSource.html#How-Ghub-uses-Auth_002dSource][Ghub's manual]] for
+details.)
+
+If you do use two-factor authentication, you must
+
+1. Manually create a GitHub token (from https://github.com/settings/tokens)
+   for scopes `repo`, `notifications` and `user` (see variable
+   ~magithub-github-token-scopes~)
+2. Store it for Magithub per user in one of your ~auth-sources~
+   (e.g. =~/.authinfo=).  Write a line like this:
+
+   #+BEGIN_EXAMPLE
+   machine api.github.com login YOUR_GITHUB_USERNAME^magithub password YOUR_GITHUB_TOKEN
+   #+END_EXAMPLE
+
+Beware that writing the token in plaintext in =~/.authinfo= (or elsewhere) is
+not secure against attackers with access to that file.  For details and
+better alternatives (like using GPG), see Ghub's manual on [[https://magit.vc/manual/ghub/Manually-Creating-and-Storing-a-Token.html#Manually-Creating-and-Storing-a-Token][Manually Creating
+and Storing a Token]] and [[https://magit.vc/manual/ghub/How-Ghub-uses-Auth_002dSource.html#How-Ghub-uses-Auth_002dSource][How Ghub uses Auth-Source]].
 
 If you want to authenticate Ghub without using Magithub, you can simply
 evaluate the following:


### PR DESCRIPTION
First, thanks for this package!

Figuring out support for two-factor authentication (2FA) wasn't trivial. Since there isn't a wizard where to paste a token and check it's correct, at least add some summarized docs, specialized for magithub—since Ghub's docs can't contain client-specific information.

Notes:

- I don't like this solution, I just like it better than just filing an issue.

- Feel free to move that info to a 2FA subsection, but the link belongs to the intro docs since 2FA shouldn't be an obscure feature, but part of the "recommended" setup.

### Security

I'm also not sure what's adequate security for the token. Ghub's docs only say

> Secrets are stored in ~/.authinfo in plain text. If you don’t want that (good choice), then you have to customize auth-sources, e.g. by flipping the positions of the first two elements.

but I don't have GPG setup at all, let alone setup with Emacs and I don't plan to shave that yak yet — customizing auth-sources can't possibly be enough?

EDITED: So I guess that for users without 2FA tokens do get written in cleartext in `~/.authinfo`? Guess that's unavoidable until support for keystores is automated enough, and a tolerable compromise on "secure enough" client machines.