### PR TITLE
Change default of magithub.status.includeStatusHeader

### DIFF
--- a/magithub-settings.el
+++ b/magithub-settings.el
@@ -96,7 +96,7 @@
 
 (defun magithub-settings-include-status-p ()
   "Non-nil if the project status header should be included."
-  (magithub-settings--value-or "magithub.status.includeStatusHeader" t
+  (magithub-settings--value-or "magithub.status.includeStatusHeader" nil
     #'magit-get-boolean))
 
 


### PR DESCRIPTION
Unlike other information, this is not being cached.  From where I am that means that refreshing the status buffer takes 2 seconds instead of 0.2 seconds.

> - If you're fixing a bug or implementing a new feature, add something to the appropriate `RelNotes/*.org` file.
> - If it's a breaking change (i.e., it could reasonably break someone's configuration), document that in the release notes as well.

I haven't done those things yet, as I would like to know whether you are going to merge this before I do that work.