### PR TITLE
Set outline-regexp in emacs-lisp-mode

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -49,7 +49,8 @@
 (defconst magithub-github-token-scopes '(repo user notifications)
   "The authentication scopes Magithub requests.")
 
-;;; Debugging utilities
+;;; Debugging utilities
+
 (defvar magithub-debug-mode nil
   "Controls what kinds of debugging information shows.
 List of symbols.
@@ -94,7 +95,8 @@ If it does not exist, it will be created."
              (lambda (filename)
                (file-in-directory-p filename magithub-dir)))
 
-;;; Turning Magithub on/off
+;;; Turning Magithub on/off
+
 (defmacro magithub-in-data-dir (&rest forms)
   "Execute forms in `magithub-dir'.
 If `magithub-dir' does not yet exist, it and its parents will be
@@ -106,7 +108,8 @@ created automatically."
      (let ((default-directory magithub-dir))
        ,@forms)))
 
-;;; Caching; Online/Offline mode
+;;; Caching; Online/Offline mode
+
 (defun magithub-offline-p ()
   "Non-nil if Magithub is not supposed to make API requests."
   (memq (magithub-settings-cache-behavior) '(t refreshing-when-offline)))
@@ -267,7 +270,8 @@ See also `magithub-cache-ignore-class'."
 (add-hook 'kill-emacs-hook
           #'magithub-cache-write-to-disk)
 
-;;; API availability checking
+;;; API availability checking
+
 (define-error 'magithub-error "Magithub Error")
 (define-error 'magithub-api-timeout "Magithub API Timeout" 'magithub-error)
 
@@ -403,7 +407,8 @@ See `magithub--api-offline-reason'."
 
 (defalias 'magithub-api-rate-limit #'ghubp-ratelimit)
 
-;;; Repository parsing
+;;; Repository parsing
+
 (defcustom magithub-github-hosts
   (list "github.com")
   "A list of top-level domains that should be recognized as GitHub hosts.
@@ -519,7 +524,8 @@ of the form `owner/name' (as in `vermiculus/magithub')."
               (magithub-repo sparse-repo)))
           sparse-repo))))
 
-;;; Repository utilities
+;;; Repository utilities
+
 (defvar magit-magithub-repo-section-map
   (let ((m (make-sparse-keymap)))
     (define-key m [remap magit-visit-thing] #'magithub-repo-visit)
@@ -599,7 +605,8 @@ See also `magithub-repo-remotes'."
                     (string= .repo.name .remote.name))))
            (magit-list-remotes)))
 
-;;; Feature checking
+;;; Feature checking
+
 (declare-function magithub-pull-request-merge "magithub-issue-tricks"
                   (pull-request &optional args))
 (declare-function magithub-maybe-insert-ci-status-header "magithub-ci" ())
@@ -723,7 +730,8 @@ See `magithub-features'."
                (message (concat m "; " s) feature-list)
                (add-to-list 'feature-list '(t . t) t))))))
 
-;;; Getting help
+;;; Getting help
+
 (defun magithub--meta-new-issue ()
   "Open a new Magithub issue.
 See /.github/ISSUE_TEMPLATE.md in this repository."
@@ -778,7 +786,7 @@ describe the error.  If not provided, it is retrieved."
     (magithub--meta-new-issue))
   (error err-message))
 
-;;; Miscellaneous utilities
+;;; Miscellaneous utilities
 
 (defcustom magithub-datetime-format "%c"
   "The display format string for date-time values.

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -48,7 +48,8 @@
     (define-key m [remap magit-visit-thing] #'magithub-issue-personal-note)
     m))
 
-;; Core
+;;; Core
+
 (defmacro magithub-interactive-issue-or-pr (sym args doc &rest body)
   "Declare an interactive form that works on both issues and PRs.
 SYM is a postfix for the function symbol.  An appropriate prefix
@@ -109,7 +110,8 @@ See also `ghubp-get-repos-owner-repo-issues'."
         (ghubp-unpaginate
          (ghubp-get-repos-owner-repo-issues-number-comments ',repo ',issue))))))
 
-;; Finding issues and pull requests
+;;; Finding issues and pull requests
+
 (defun magithub-issues ()
   "Return a list of issue objects that are actually issues."
   (-filter #'magithub-issue--issue-is-issue-p
@@ -120,7 +122,8 @@ See also `ghubp-get-repos-owner-repo-issues'."
   (-filter #'magithub-issue--issue-is-pull-p
            (magithub--issue-list)))
 
-;; Sorting
+;;; Sorting
+
 (defcustom magithub-issue-sort-function
   #'magithub-issue-sort-ascending
   "Function used for sorting issues and pull requests in the
@@ -140,7 +143,8 @@ status buffer.  Should take two issue-objects as arguments."
   "Sort ISSUES by `magithub-issue-sort-function'."
   (sort issues magithub-issue-sort-function))
 
-;; Getting issues from the user
+;;; Getting issues from the user
+
 (defun magithub-issue--format-for-read (issue)
   "Format ISSUE as a string suitable for completion."
   (let-alist issue (format "%3d %s" .number .title)))
@@ -390,7 +394,8 @@ Each function takes two arguments:
     (magithub-label-insert-list .labels)
     (insert "\n")))
 
-;; Magithub-Status stuff
+;;; Magithub-Status stuff
+
 
 (defun magithub-issue-refresh (even-if-offline)
   "Refresh issues for this repository.
@@ -441,9 +446,9 @@ we'll hit the API) if Magithub is offline."
     map)
   "Keymap for `magithub-pull-request-list' sections.")
 
-;;; By maintaining these as lists of functions, we're setting
-;;; ourselves up to be able to dynamically apply new filters from the
-;;; status buffer (e.g., 'bugs' or 'questions' assigned to me)
+;; By maintaining these as lists of functions, we're setting
+;; ourselves up to be able to dynamically apply new filters from the
+;; status buffer (e.g., 'bugs' or 'questions' assigned to me)
 (defcustom magithub-issue-issue-filter-functions nil
   "List of functions that filter issues.
 Each function will be supplied a single issue object.  If any
@@ -560,7 +565,8 @@ Interactively, this finds the issue at point."
   (when (magithub-usable-p)
     (number-to-string (length (magithub-pull-requests)))))
 
-;; Pull Request handling
+;;; Pull Request handling
+
 
 (defun magithub-pull-request (repo number)
   "Retrieve a pull request in REPO by NUMBER."


### PR DESCRIPTION
By default `outline-minor-mode` treats comments that begin with three
or more semicolons as headings.  Adjust `outline-regexp` to also
recognize the non-standard headers that are being used in some of the
libraries.  And do not use three semicolons for non-heading comments.

Or you could just stop using `^L;; Heading`. Also there might be other non-heading comments that begin with three semicolons in files I didn't look at. And you might want to try out `outline-minor-mode`.
