### PR TITLE
Use magit-unwind-refresh-hook to restore magithub-settings-cache-behavior-override

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -1138,12 +1138,10 @@ COMPARE is used on the application of ACCESSOR to each argument."
   (interactive)
   (magit-section-show-level -5))
 
-(defvar magithub-reset-settings-cache-behavior-override nil)
 (defun magithub-reset-settings-cache-behavior-override ()
   "Reset everything to the defaults after refreshing.
 To be added to `magit-unwind-refresh-hook'."
-  (setq magithub-settings-cache-behavior-override
-	magithub-reset-settings-cache-behavior-override)
+  (setq magithub-settings-cache-behavior-override 'none)
   (setq magithub-cache--refreshed-forms nil))
 
 (defun magithub-refresh ()
@@ -1151,8 +1149,6 @@ To be added to `magit-unwind-refresh-hook'."
 Use directly at your own peril; this is intended for use with
 `magit-pre-refresh-hook'."
   (interactive (user-error (substitute-command-keys "This is no longer an interactive function; use \\[universal-argument] \\[magit-refresh] instead :-)")))
-  (setq magithub-reset-settings-cache-behavior-override
-	magithub-settings-cache-behavior-override)
   (when (and current-prefix-arg
              (magithub-usable-p)
              (magithub-confirm-no-error 'refresh)

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -190,8 +190,9 @@ AFTER-UPDATE is a function to run after the cache is updated."
                (run-with-idle-timer 600 nil #'magithub-cache-write-to-disk)
                (when refreshing
                  (push entry magithub-cache--refreshed-forms))
-               (when (functionp after-update)
-                 (funcall after-update new-value))))
+               (if (functionp after-update)
+                   (funcall after-update new-value)
+		 new-value)))
         cached-value)))
 
 (defun magithub-cache-invalidate ()


### PR DESCRIPTION
This is cleaner and should be safer. However if an error occurs during refresh, then the hook might not be run, which could be addressed by adding a new `magit-unwind-refresh-hook` https://github.com/magit/magit/commit/ff517ea3733abac93a7d6ce27721e7685a045d49.
