### PR TITLE
Make offline mode simpler

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -47,7 +47,14 @@
 - =hub.host= is no longer respected and has been replaced by user option
   ~magithub-github-hosts~.  This most directly impacts GitHub Enterprise
   support.
-- ~magithub-cache-invalidate~ was not used, so it is no longer available.
+** Caching  [[PR:328]]
+Caching has been reworked mostly from the ground-up.  'Offline mode'
+is now manifest in a single, Boolean-valued git variable
+"magithub.cache", which see.
+
+- ~magithub-cache-invalidate~ was not used, so it is no longer
+  available.
+- ~magithub-issue-refresh~ no longer takes parameters.
 
 * New Features
 - Browse commits by using =w= on a commit section.  If the current

--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -47,6 +47,7 @@
 - =hub.host= is no longer respected and has been replaced by user option
   ~magithub-github-hosts~.  This most directly impacts GitHub Enterprise
   support.
+- ~magithub-cache-invalidate~ was not used, so it is no longer available.
 
 * New Features
 - Browse commits by using =w= on a commit section.  If the current

--- a/magithub-ci.el
+++ b/magithub-ci.el
@@ -103,7 +103,7 @@ remote counterpart."
   (setq branch (or branch (magit-get-current-branch)))
   (if-let ((pull-request
             (or (magithub-pull-request-branch->pr--gitconfig branch)
-                (and (not (magithub-offline-p))
+                (and (magithub-online-p)
                      (with-demoted-errors "Error: %S"
                        (magithub-pull-request-branch->pr--ghub branch))))))
       (let-alist pull-request .head.sha)
@@ -196,11 +196,9 @@ remote counterpart."
   "Keymap for `magithub-ci-status' header section.")
 
 (defun magithub-ci-refresh ()
-  "Invalidate the CI cache and refresh the buffer.
-If EVEN-IF-OFFLINE is non-nil, we'll still refresh (that is,
-we'll hit the API) if Magithub is offline."
+  "Invalidate the CI cache and refresh the buffer."
   (interactive)
-  (when (magithub-offline-p)
+  (unless (magithub-online-p)
     (magithub-confirm 'ci-refresh-when-offline))
   (magithub-cache-without-cache :ci-status
     (magithub-ci-status (magithub-ci-status--get-default-ref)))

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -180,8 +180,9 @@ AFTER-UPDATE is a function to run after the cache is updated."
     (or (and recalc
              (prog1 (setq new-value (with-temp-message message (eval form)))
                (puthash entry new-value magithub-cache--cache)
-               (setq magithub-cache--needs-write t)
-               (run-with-idle-timer 600 nil #'magithub-cache-write-to-disk)
+               (unless magithub-cache--needs-write
+                 (setq magithub-cache--needs-write t)
+                 (run-with-idle-timer 600 nil #'magithub-cache-write-to-disk))
                (when refreshing
                  (push entry magithub-cache--refreshed-forms))
                (if (functionp after-update)

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -248,7 +248,7 @@ Returns \"Xd Xh Xm Xs\" (counting from zero)"
 
 (defun magithub-cache-write-to-disk ()
   "Write the cache to disk.
-The cache is writtin to `magithub-cache-file' in
+The cache is written to `magithub-cache-file' in
 `magithub-dir'"
   (if (active-minibuffer-window)
       (run-with-idle-timer 600 nil #'magithub-cache-write-to-disk) ;defer

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -190,13 +190,6 @@ AFTER-UPDATE is a function to run after the cache is updated."
 		 new-value)))
         cached-value)))
 
-(defun magithub-cache-invalidate ()
-  "Clear the cache from memory."
-  (maphash
-   (lambda (k _)
-     (remhash k magithub-cache--cache))
-   magithub-cache--cache))
-
 (defun magithub-maybe-report-offline-mode ()
   "Conditionally inserts the OFFLINE header.
 If this is a Magithub-enabled repository and we're offline, we

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -401,16 +401,11 @@ Each function takes two arguments:
 
 ;;; Magithub-Status stuff
 
-
-(defun magithub-issue-refresh (even-if-offline)
-  "Refresh issues for this repository.
-If EVEN-IF-OFFLINE is non-nil, we'll still refresh (that is,
-we'll hit the API) if Magithub is offline."
-  (interactive "P")
-  (let ((magithub-settings-cache-behavior-override
-         (if even-if-offline nil (magithub-settings-cache-behavior))))
-    (magithub-cache-without-cache :issues
-      (ignore (magithub--issue-list))))
+(defun magithub-issue-refresh ()
+  "Refresh issues for this repository."
+  (interactive)
+  (magithub-cache-without-cache :issues
+    (magithub--issue-list))
   (when (derived-mode-p 'magit-status-mode)
     (magit-refresh)))
 

--- a/magithub-settings.el
+++ b/magithub-settings.el
@@ -43,7 +43,8 @@
                 (magit--set-popup-variable ,variable ,choices ,default))
          (defun ,(intern Nfmt) () ,(format "See `%s'." Nset)
                 (magit--format-popup-variable:choices ,variable ,choices ,default))
-         (magit-define-popup-variable ',popup ,key ,variable ',Sset ',Sfmt)))))
+         (magit-define-popup-variable ',popup ,key ,variable ',Sset ',Sfmt)
+         ,variable))))
 
 (defun magithub-settings--value-or (variable default &optional accessor)
   (declare (indent 2))

--- a/magithub-settings.el
+++ b/magithub-settings.el
@@ -62,6 +62,7 @@
   '("true" "false") "true")
 
 (defun magithub-enabled-p ()
+  "Returns non-nil if Magithub content is available."
   (magithub-settings--value-or "magithub.enabled" t
     #'magit-get-boolean))
 

--- a/magithub-settings.el
+++ b/magithub-settings.el
@@ -66,28 +66,23 @@
   (magithub-settings--value-or "magithub.enabled" t
     #'magit-get-boolean))
 
-(magithub-settings--simple magithub-settings-popup ?c "cache"
-  "Controls the cache.
+(magithub-settings--simple magithub-settings-popup ?o "online"
+  "Controls whether Magithub is online or offline.
 
-- `always': The cache will not be used, but it will be updated
+- `true': requests are made to GitHub for missing data
+- `false': no requests are made to GitHub
 
-- `never': The cache is never used.  Data is always re-retrieved
-           when online.  When offline, there is simply no data.
+In both cases, when there is data in the cache, that data is
+used.  Refresh the buffer with a prefix argument to disregard the
+cache while refreshing: \\<magit-mode-map>\\[universal-argument] \\[magit-refresh]"
+  '("true" "false") "true")
 
-- `whenPresent': The cache is used if it exists.  If there is
-                 nothing cached, data is retrieved when online.
-                 When offline, there is simply no data."
-  '("always" "never" "whenPresent") "whenPresent")
+(defun magithub-online-p ()
+  "See `magithub-settings--set-magithub.online'.
+Returns the value as t or nil."
+  (magithub-settings--value-or "magithub.online" t
+    #'magit-get-boolean))
 
-(defvar magithub-settings-cache-behavior-override 'none)
-(defun magithub-settings-cache-behavior ()
-  (if (not (eq magithub-settings-cache-behavior-override 'none))
-      magithub-settings-cache-behavior-override
-    (pcase (magithub-settings--value-or "magithub.cache" "whenPresent")
-      ("always" t)
-      ("never" nil)
-      ("whenPresent" 'when-present)
-      (_ 'when-present))))
 
 (magithub-settings--simple magithub-settings-popup ?s "status.includeStatusHeader"
   "When true, the project status header is included in

--- a/test/magithub-test.el
+++ b/test/magithub-test.el
@@ -40,9 +40,8 @@ cached API calls."
   (let ((magithub--api-last-checked (current-time)))
     (should (magithub-source--sparse-repo))
     (should (magithub-repo))
-    (should (let ((magithub-settings-cache-behavior-override t))     ; force API call
+    (should (let ((magithub-cache--refresh t)) ; force API call
               (magithub-repo)))
-    (should (let ((magithub-settings-cache-behavior-override nil))   ; force cache read
-              (magithub-repo)))))
+    (should (magithub-repo))))                 ; force cache read
 
 ;;; magithub-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -32,8 +32,8 @@ variable is not set, offer to save a snapshot of the real API's
 response."
   (message "(mock-ghub-request %S %S %S :query %S :payload %S :headers %S :unpaginate %S :noerror %S :reader %S :username %S :auth %S :host %S)"
            method resource params query payload headers unpaginate noerror reader username auth host)
-  (when (eq t (magithub-settings-cache-behavior))
-    (error "Did not respect cache"))
+  (when (not (magithub-online-p))
+    (error "Did not respect online/offline"))
   (let* ((parts (cdr (s-split "/" resource)))
          (directory (mapconcat (lambda (s) (concat s ".d"))
                                (butlast parts) "/"))


### PR DESCRIPTION
This is pursuant to the conversation in #304.

Online/offline functionality is now controlled by the single Boolean git variable "magithub.online", whose values are documented within `magithub-settings-popup`:

- `true`: requests are made to GitHub for missing data
- `false`: no requests are made to GitHub