### PR TITLE
makes magithub-clone asynchronous

### DIFF
--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -107,6 +107,9 @@ for that behavior.
   ~magithub-features~ mechanism.  [[PR:263]], [[PR:278]]
 
 * Bug Fixes
+- ~magithub-clone~ is now asynchonous, and defers to the user whether
+  or not to display the magit-process-bufer according to the value of
+  ~magit-process-popup-time~..
 - In ~magithub-repo~, an API request is no longer made when the
   repository context cannot be determined.
 - The list of labels is now correctly cached per-repository.  [[PR:203]]

--- a/RelNotes/0.1.6.org
+++ b/RelNotes/0.1.6.org
@@ -108,8 +108,8 @@ for that behavior.
 
 * Bug Fixes
 - ~magithub-clone~ is now asynchonous, and defers to the user whether
-  or not to display the magit-process-bufer according to the value of
-  ~magit-process-popup-time~..
+  or not to display the magit-process-buffer according to the value of
+  ~magit-process-popup-time~.  [[https://github.com/vermiculus/magithub/pull/340][PR:340]]
 - In ~magithub-repo~, an API request is no longer made when the
   repository context cannot be determined.
 - The list of labels is now correctly cached per-repository.  [[PR:203]]

--- a/magithub.el
+++ b/magithub.el
@@ -269,7 +269,7 @@ See also `magithub-preferred-remote-method'."
               (add-function
                :after
                (process-sentinel magit-this-process)
-               (lambda (process event)
+               (lambda (process _event)
                  (unless (process-live-p process)
                    (when set-upstream
                      (let ((upstream "upstream"))


### PR DESCRIPTION
How the process buffer should be displayed, or whether to even display
it at all is left up to the user. See `magit-process-popup-time'.
