### PR TITLE
Temporarily disable require-final-newline when writing cache

### DIFF
--- a/RelNotes/0.2.org
+++ b/RelNotes/0.2.org
@@ -3,3 +3,7 @@
 
 #+LINK: PR https://www.github.com/vermiculus/magithub/pull/%s
 #+LINK: BUG https://www.github.com/vermiculus/magithub/issues/%s
+
+* Bug Fixes
+- ~magithub-cache-write-to-disk~ now will write to the disk without prompting
+  when ~require-final-newline~ is set to t.  [[PR:343]]

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -237,8 +237,9 @@ The cache is written to `magithub-cache-file' in
     (when magithub-cache--needs-write
       (magithub-in-data-dir
        (with-temp-buffer
-         (insert (prin1-to-string magithub-cache--cache))
-         (write-file magithub-cache-file)))
+         (let ((require-final-newline nil))
+           (insert (prin1-to-string magithub-cache--cache))
+           (write-file magithub-cache-file))))
       (setq magithub-cache--needs-write nil)
       (magithub-debug-message "wrote cache to disk: %S"
 			      (expand-file-name magithub-cache-file


### PR DESCRIPTION
If the user has `require-final-newline` set to t, writing to any file will require a newline, but `prin1-to-string` doesn't output a newline, this PR temporarily disables it when writing to it so when I exit emacs, it won't prompt me to put a newline to the cache file.