### PR TITLE
Set up magithub-edit-mode after associating draft with a file

### DIFF
--- a/magithub-edit-mode.el
+++ b/magithub-edit-mode.el
@@ -167,6 +167,12 @@ ask to save a draft here if post is cancelled."
         (kill-buffer (current-buffer))))
 
     (with-current-buffer (get-buffer-create buffer-name)
+      (when file
+        (let ((orig-name (buffer-name))
+              (dir default-directory))
+          (set-visited-file-name file)
+          (rename-buffer orig-name)
+          (cd dir)))
       (magithub-edit-mode)
 
       (setq magithub-edit-previous-buffer prevbuf
@@ -178,13 +184,6 @@ ask to save a draft here if post is cancelled."
           (when header
             (setq line (concat line " | " header)))
           line)))
-
-      (when file
-        (let ((orig-name (buffer-name))
-              (dir default-directory))
-          (set-visited-file-name file)
-          (rename-buffer orig-name)
-          (cd dir)))
 
       (cond
        (draft


### PR DESCRIPTION
When restoring from a draft (even if the file doesn't exist), setting the buffer's file clears the major mode for some reason. Setting up magithub-edit-mode after associating the draft buffer fixes this problem, and makes magithub edit mode buffers come up in the right mode regardless of whether there was a draft file associated with them or not.