### PR TITLE
Don't ask if only one remote option is available

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -560,22 +560,25 @@ GitHub repositories."
                         (cons r repo)))
                     (magit-list-remotes))))
 
-(defun magithub-read-repo (prompt &optional default-input)
+(defun magithub-read-repo (prompt &optional default-input skip-prompt-for-sole-remote)
   "Using PROMPT, read a GitHub repository.
-See also `magithub-repo-remotes'."
+See also `magithub-repo-remotes'.
+If there's only one remote available, optionally return it without prompting."
   (let* ((remotes (magithub-repo-remotes))
          (maxlen (->> remotes
                       (mapcar #'car)
                       (mapcar #'length)
                       (apply #'max)))
          (fmt (format "%%-%ds (%%s/%%s)" maxlen)))
-    (magithub-repo
-     (cdr (magithub--completing-read
-           prompt (magithub-repo-remotes)
-           (lambda (remote-repo-pair)
-             (let-alist (cdr remote-repo-pair)
-               (format fmt (car remote-repo-pair) .owner.login .name)))
-           nil nil nil default-input)))))
+    (if (and skip-prompt-for-sole-remote (= (length remotes) 1))
+        (car remotes)
+      (magithub-repo
+       (cdr (magithub--completing-read
+             prompt (magithub-repo-remotes)
+             (lambda (remote-repo-pair)
+               (let-alist (cdr remote-repo-pair)
+                 (format fmt (car remote-repo-pair) .owner.login .name)))
+             nil nil nil default-input))))))
 
 (defun magithub-repo-remotes-for-repo (repo)
   (-filter (lambda (remote)

--- a/magithub-issue-post.el
+++ b/magithub-issue-post.el
@@ -127,7 +127,7 @@ See also URL
 (defun magithub-pull-request-new-arguments ()
   (unless (magit-get-push-remote)
     (user-error "Nothing on remote yet; have you pushed your branch?  Aborting"))
-  (let* ((this-repo (magithub-read-repo "Fork's remote (this is you!) " (ghubp-username)))
+  (let* ((this-repo (magithub-read-repo "Fork's remote (this is you!) " (ghubp-username) t))
          (this-repo-owner (let-alist this-repo .owner.login))
          (parent-repo (or (alist-get 'parent this-repo) this-repo))
          (this-remote (car (magithub-repo-remotes-for-repo this-repo)))


### PR DESCRIPTION
When only one remote repo is defined (e.g. my situation with work repos, where I am directly submitting to `origin`) it seems superfluous to confirm the remote every time I submit a PR. So this adds a function to auto-select the remote if it's the only one, when submitting a PR. There is also a custom option to turn on / off this behavior.