### PR TITLE
Fix type of custom variable maghub-github-hosts

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -395,7 +395,7 @@ See `magithub--api-offline-reason'."
   "A list of top-level domains that should be recognized as GitHub hosts.
 See also `magithub-github-repository-p'."
   :group 'magithub
-  :type '(list string))
+  :type '(repeat string))
 
 (defun magithub-github-repository-p ()
   "Non-nil if \"origin\" points to GitHub or a whitelisted domain.


### PR DESCRIPTION
The custom variable `maghub-github-hosts` was identified as being of
type `(list string)`, which only allows a single `string` value. It
was corrected to be `(repeat string)` which allows multiple host names
to be added through the customization interface.