### PR TITLE
Automatically show number of commits since latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/vermiculus/magithub.svg?branch=master)](https://travis-ci.org/vermiculus/magithub)
 [![Gitter](https://badges.gitter.im/vermiculus/magithub.svg)](https://gitter.im/vermiculus/magithub)
 [![MELPA Stable Status](http://melpa-stable.milkbox.net/packages/magithub-badge.svg)](http://melpa-stable.milkbox.net/#/magithub)
-[![GitHub Commits](https://img.shields.io/github/commits-since/vermiculus/magithub/0.1.6.svg)](//github.com/vermiculus/magithub/releases)
+[![GitHub Commits](https://img.shields.io/github/commits-since/vermiculus/magithub/latest.svg)](//github.com/vermiculus/magithub/releases)
 
 Magithub is a collection of interfaces to GitHub integrated into
 [Magit][magit] workflows:


### PR DESCRIPTION
Instead of needing to update to the latest tag on every commit, Shields.io provides a badge for always showing the number of commits since the latest tag.

One downside of this change is that it looks like you need to explicitly create a release in GitHub for Shields.io to pick it up. You might prefer just doing it manually?