### PR TITLE
Don't try to add action to non-existent Magit popup

### DIFF
--- a/magithub-core.el
+++ b/magithub-core.el
@@ -607,10 +607,12 @@ If there's only one remote available, optionally return it without prompting."
 (defconst magithub-feature-list
   ;; features must only return nil if they fail to install
   `((pull-request-merge . ,(lambda ()
-                             (magit-define-popup-action 'magit-am-popup
-                               ?P "Apply patches from pull request"
-                               #'magithub-pull-request-merge)
-                             t))
+                             (require 'magit-popup nil t)
+                             (when (boundp 'magit-am-popup)
+                               (magit-define-popup-action 'magit-am-popup
+                                 ?P "Apply patches from pull request"
+                                 #'magithub-pull-request-merge)
+                               t)))
 
     (commit-browse . ,(lambda ()
                         (define-key magit-commit-section-map "w"

--- a/magithub.el
+++ b/magithub.el
@@ -77,8 +77,10 @@
 ;;;###autoload
 (eval-after-load 'magit
   '(progn
-     (magit-define-popup-action 'magit-dispatch-popup
-       ?H "Magithub" #'magithub-dispatch-popup ?!)
+     (require 'magit-popup)
+     (when (boundp 'magit-dispatch-popup)
+       (magit-define-popup-action 'magit-dispatch-popup
+         ?H "Magithub" #'magithub-dispatch-popup ?!))
      (define-key magit-status-mode-map
        "H" #'magithub-dispatch-popup)))
 


### PR DESCRIPTION
Later this year `magit` will start using `transient` instead
of `magit-popup`.  Extensions to `magit` may continue to use
`magit-popup` but they cannot add any additional actions to
`magit`'s popups because there no longer are any such popups.

`transient` does not yet allow adding new suffix commands to
existing prefix commands.

Also make sure `magit-popup` is loaded before trying to use
a function defined by it, preventing an error when it is not.