### PR TITLE
Speed up github datetime parsing

### DIFF
--- a/RelNotes/0.2.org
+++ b/RelNotes/0.2.org
@@ -17,3 +17,4 @@
 - Browse files with ~magithub-browse-file~.  Supports file-visiting
   buffers with active regions as well as dired- and magit-status-like
   buffers.  Blame the file with ~magithub-browse-file-blame~.  [[PR:377]]
+- Speed github datetime parsing.  [[PR:393]]

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -790,7 +790,7 @@ See also `format-time-string'."
 (defun magithub--parse-number (string)
   "Parse a STRING into a number and return nil if parsing failed."
   (let ((number (string-to-number string)))
-    (if (string-equal string (number-to-string number))
+    (if (string-equal string (format "%02d" number))
         number
       nil)))
 

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -787,13 +787,6 @@ See also `format-time-string'."
   :group 'magithub
   :type 'string)
 
-(defun magithub--parse-number (string)
-  "Parse a STRING into a number and return nil if parsing failed."
-  (let ((number (string-to-number string)))
-    (if (string-equal string (format "%02d" number))
-        number
-      nil)))
-
 (defun magithub--parse-time-string (iso8601)
   "Parse ISO8601 into a time value.
 ISO8601 is expected to not have a TZ component.

--- a/magithub-core.el
+++ b/magithub-core.el
@@ -800,13 +800,15 @@ ISO8601 is expected to not have a TZ component.
 
 We first use a crude parsing and if it fails we fall back to a more
 general purpose function.  This is done to speed up parsing time."
-  (if-let ((year (magithub--parse-number (substring iso8601 0 4)))
-           (month (magithub--parse-number (substring iso8601 5 7)))
-           (day (magithub--parse-number (substring iso8601 8 10)))
-           (hour (magithub--parse-number (substring iso8601 11 13)))
-           (minute (magithub--parse-number (substring iso8601 14 16)))
-           (second (magithub--parse-number (substring iso8601 17 19))))
-      (encode-time second minute hour day month year t)
+  (if (string-match "^\\([0-9]+\\)-\\([0-9]+\\)-\\([0-9]+\\)T\\([0-9]+\\):\\([0-9]+\\):\\([0-9]+\\)Z$" iso8601)
+    (encode-time
+     (string-to-number (match-string 6 iso8601))
+     (string-to-number (match-string 5 iso8601))
+     (string-to-number (match-string 4 iso8601))
+     (string-to-number (match-string 3 iso8601))
+     (string-to-number (match-string 2 iso8601))
+     (string-to-number (match-string 1 iso8601))
+     t)
     (parse-iso8601-time-string (concat iso8601 "+00:00"))))
 
 (defun magithub--format-time (time)

--- a/test/magithub-test.el
+++ b/test/magithub-test.el
@@ -44,4 +44,17 @@ cached API calls."
               (magithub-repo)))
     (should (magithub-repo))))                 ; force cache read
 
+(ert-deftest magithub-test-parse-number ()
+  "Test parsing of number."
+  (should (equal 10 (magithub--parse-number "10")))
+  (should (equal 0 (magithub--parse-number "0")))
+  (should (equal nil (magithub--parse-number "X"))))
+
+(ert-deftest magithub-test-parse-time-string ()
+  "Test parsing of datetime."
+  (should (equal '(23253 12274) (magithub--parse-time-string "2018-04-16T23:21:22Z")))
+  (should (equal '(23253 12274) (magithub--parse-time-string "2018-04-16T23:21:22")))
+  (should (equal '(23253 12274) (magithub--parse-time-string "2018-04-16T2321:22")))
+  (should-error (magithub--parse-time-string "2018-04-16T23:21:2XZ")))
+
 ;;; magithub-test.el ends here

--- a/test/magithub-test.el
+++ b/test/magithub-test.el
@@ -48,6 +48,7 @@ cached API calls."
   "Test parsing of number."
   (should (equal 10 (magithub--parse-number "10")))
   (should (equal 0 (magithub--parse-number "0")))
+  (should (equal 0 (magithub--parse-number "01")))
   (should (equal nil (magithub--parse-number "X"))))
 
 (ert-deftest magithub-test-parse-time-string ()

--- a/test/magithub-test.el
+++ b/test/magithub-test.el
@@ -44,13 +44,6 @@ cached API calls."
               (magithub-repo)))
     (should (magithub-repo))))                 ; force cache read
 
-(ert-deftest magithub-test-parse-number ()
-  "Test parsing of number."
-  (should (equal 10 (magithub--parse-number "10")))
-  (should (equal 0 (magithub--parse-number "0")))
-  (should (equal 0 (magithub--parse-number "01")))
-  (should (equal nil (magithub--parse-number "X"))))
-
 (ert-deftest magithub-test-parse-time-string ()
   "Test parsing of datetime."
   (should (equal '(23253 12274) (magithub--parse-time-string "2018-04-16T23:21:22Z")))


### PR DESCRIPTION
Magit-status on a repo containing 300 opened PRs took a lot of time.  Profiling showed the parse-iso8601-time-string was taking roughly 20%.

This solution uses a crude parsing and falls back to using parse-iso8601-time-string in case of error.

Solves #349 partially.