### PR TITLE
Speed up ghubp-host call

### DIFF
--- a/RelNotes/0.2.org
+++ b/RelNotes/0.2.org
@@ -17,3 +17,4 @@
 - Browse files with ~magithub-browse-file~.  Supports file-visiting
   buffers with active regions as well as dired- and magit-status-like
   buffers.  Blame the file with ~magithub-browse-file-blame~.  [[PR:377]]
+- Speed up magit-status by caching results of ghubp-host.  [[PR:394]]

--- a/magithub-issue.el
+++ b/magithub-issue.el
@@ -281,6 +281,23 @@ This is stored in `magit-git-dir' and is unrelated to
                   (insert-file-contents-literally filename)
                   (buffer-string))))))))
 
+
+(defun magithub--ghubp-host ()
+  "Calls ghubp-host and cache result.
+
+Caching is done to speed up showing PRs for repos with a lot of opened
+PRs."
+  (when (not (hash-table-p magithub--ghubp-host-result))
+    (setq magithub--ghubp-host-result (make-hash-table :test 'equal)))
+
+  (if-let ((cached-result (gethash default-directory magithub--ghubp-host-result nil)))
+      cached-result
+    (puthash default-directory (ghubp-host) magithub--ghubp-host-result)))
+
+(defvar magithub--ghubp-host-result (make-hash-table :test 'equal)
+  "Cache result of magithub-ghubp-host.")
+
+
 (defun magithub-issue-repo (issue)
   "Get a repository object from ISSUE."
   (let-alist issue
@@ -289,7 +306,7 @@ This is stored in `magit-git-dir' and is unrelated to
         (save-match-data
           (when (string-match (concat (rx bos)
                                       "https://"
-                                      (regexp-quote (ghubp-host))
+                                      (regexp-quote (magithub--ghubp-host))
                                       (rx "/repos/"
                                           (group (+ (not (any "/")))) "/"
                                           (group (+ (not (any "/")))) "/issues/")


### PR DESCRIPTION
Magit-status on a repo containing 300 opened PRs took a lot of time.  Profiling showed ghubp-host was taking roughly 35%.

This solution uses a hash table to cache the results.

Solves #349 partially.

**This PR is not complete, we need a way to refresh the cache**

For example, after calling `magit-status` on this repo, the variable contains:
```elisp
#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data
("/Users/ibizaman/.emacs.d/straight/repos/magithub/" "api.github.com"))
```
Then after `magit-status` on the `ghub` repo:
```elisp
#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data
("/Users/ibizaman/.emacs.d/straight/repos/magithub/" "api.github.com" "/Users/ibizaman/.emacs.d/straight/repos/ghub/" "api.github.com"))
```